### PR TITLE
Add general project direction and user stories for DG

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -270,10 +270,9 @@ particular, this representative works with B2B sales.
 * can type fast
 * prefers typing to mouse interactions
 * is reasonably comfortable using CLI apps
-* has a need to transfer large number of contacts to new workers
 
-**Value proposition**: manage and organise large number of contacts faster than a
-typical mouse/GUI driven app
+**Value proposition**: Efficiently manage and organise a large number of contacts
+faster than a typical mouse/GUI driven app
 
 
 ### User stories

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -307,8 +307,6 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 | `*`      | experienced user | use keyboard shortcuts                                                      | navigate the app faster                                           |
 | `*`      | sales rep        | contact my client quickly from the app                                      | avoid typing numbers repeatedly on my phone                       |
 
-*{More to be added}*
-
 ### Use cases
 
 (For all use cases below, the **System** is the `AddressBook` and the **Actor** is the `user`, unless specified otherwise)

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -262,13 +262,18 @@ _{Explain here how the data archiving feature will be implemented}_
 
 **Target user profile**:
 
-* has a need to manage a significant number of contacts
+A sales and customer relations representative working in the F&B industry. In
+particular, this representative works with B2B transactions.
+
+* has a need to manage a significant number of business contacts
 * prefer desktop apps over other types
 * can type fast
 * prefers typing to mouse interactions
 * is reasonably comfortable using CLI apps
+* has a need to transfer large number of contacts to new workers
 
-**Value proposition**: manage contacts faster than a typical mouse/GUI driven app
+**Value proposition**: manage and organise large number of contacts faster than a
+typical mouse/GUI driven app
 
 
 ### User stories

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -280,14 +280,32 @@ typical mouse/GUI driven app
 
 Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unlikely to have) - `*`
 
-| Priority | As a …​                                    | I want to …​                     | So that I can…​                                                        |
-| -------- | ------------------------------------------ | ------------------------------ | ---------------------------------------------------------------------- |
-| `* * *`  | new user                                   | see usage instructions         | refer to instructions when I forget how to use the App                 |
-| `* * *`  | user                                       | add a new person               |                                                                        |
-| `* * *`  | user                                       | delete a person                | remove entries that I no longer need                                   |
-| `* * *`  | user                                       | find a person by name          | locate details of persons without having to go through the entire list |
-| `* *`    | user                                       | hide private contact details   | minimize chance of someone else seeing them by accident                |
-| `*`      | user with many persons in the address book | sort persons by name           | locate a person easily                                                 |
+| Priority | As a …           | I want to …                                                                 | So that I can …                                                   |
+|----------|------------------|-----------------------------------------------------------------------------|-------------------------------------------------------------------|
+| `* * *`  | user             | add new contacts                                                            | save the contact information of people                            |
+| `* * *`  | user             | delete a contact                                                            | free up space in my app                                           |
+| `* * *`  | user             | view all contact                                                            | retrieve contact information                                      |
+| `* * *`  | user             | save all contact                                                            | retain all information for when i reopen the app                  |
+| `* * *`  | sales rep        | have a low query time                                                       | avoid wasting much time querying my desired contact               |
+| `* *`    | user             | search through my contacts                                                  | find a specific person                                            |
+| `* *`    | user             | view all commands                                                           | know how to use the app                                           |
+| `* *`    | user             | edit contact                                                                | update contact with new information                               |
+| `* *`    | user             | sort contact by name                                                        | see whose contact I have saved                                    |
+| `* *`    | user             | archive contact                                                             | hide less frequently used contacts without deleting them          |
+| `* *`    | user             | be alerted when a contact already exist                                     | avoid accidentally creating a duplicate                           |
+| `* *`    | user             | undo a command                                                              | fix a mistake I made                                              |
+| `* *`    | new user         | import all contact details into the app                                     | start using without manual setup                                  |
+| `* *`    | sales rep        | keep track of clients I have contacted by seeing when I last contacted them | avoid wasting time calling them again about the same product      |
+| `* *`    | sales rep        | view my most popular/active clients                                         | promote the new product                                           |
+| `* *`    | sales rep        | remember the client's preferred products                                    | recommend related products                                        |
+| `* *`    | sales rep        | add notes to client's contact                                               | keep track of my conversation with them                           |
+| `* *`    | sales rep        | group my clients by industry                                                | tell if sales are doing well in that industry among other metrics |
+| `* *`    | sales rep        | add tags to clients                                                         | categorize them                                                   |
+| `* *`    | sales rep        | keep note of my client's email addresses                                    | potentially send promotions or survey forms                       |
+| `* *`    | sales rep        | export a list of contact emails                                             | add them to a mailing list                                        |
+| `* *`    | sales rep        | add a tag to multiple clients                                               | tag the clients more easily                                       |
+| `*`      | experienced user | use keyboard shortcuts                                                      | navigate the app faster                                           |
+| `*`      | sales rep        | contact my client quickly from the app                                      | avoid typing numbers repeatedly on my phone                       |
 
 *{More to be added}*
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -263,7 +263,7 @@ _{Explain here how the data archiving feature will be implemented}_
 **Target user profile**:
 
 A sales and customer relations representative working in the F&B industry. In
-particular, this representative works with B2B transactions.
+particular, this representative works with B2B sales.
 
 * has a need to manage a significant number of business contacts
 * prefer desktop apps over other types


### PR DESCRIPTION
Closes #77

The target user profile is taken from the main Google document and adapted to fit to the developer guide format. As you can see, nothing much is changed, just providing some context to the given user profile.

User stories are copied from the Consolidated User Stories sheet with some slight modification to the wording for the "So that I can..." column.