### PR TITLE
Replace focusedPerson with an Observable object

### DIFF
--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -2,6 +2,7 @@ package seedu.address.logic;
 
 import java.nio.file.Path;
 
+import javafx.beans.property.ObjectProperty;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.commands.CommandResult;
@@ -47,7 +48,7 @@ public interface Logic {
     /**
      * Returns the person who will be focused on.
      */
-    Person getFocusedPerson();
+    ObjectProperty<Person> getFocusedPerson();
 
     /**
      * Set the user prefs' GUI settings.

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -5,6 +5,7 @@ import java.nio.file.AccessDeniedException;
 import java.nio.file.Path;
 import java.util.logging.Logger;
 
+import javafx.beans.property.ObjectProperty;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
@@ -82,7 +83,7 @@ public class LogicManager implements Logic {
     }
 
     @Override
-    public Person getFocusedPerson() {
+    public ObjectProperty<Person> getFocusedPerson() {
         return model.getFocusedPerson();
     }
 

--- a/src/main/java/seedu/address/logic/commands/AddNotesCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddNotesCommand.java
@@ -74,7 +74,7 @@ public class AddNotesCommand extends Command {
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
 
-        model.setFocusedPerson(this.index);
+        model.getFocusedPerson().set(editedPerson);
 
         return new CommandResult(String.format(generateSuccessMessage(editedPerson), index.getOneBased()),
                 false, false, true);

--- a/src/main/java/seedu/address/logic/commands/AddNotesCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddNotesCommand.java
@@ -77,7 +77,7 @@ public class AddNotesCommand extends Command {
         model.getFocusedPerson().set(editedPerson);
 
         return new CommandResult(String.format(generateSuccessMessage(editedPerson), index.getOneBased()),
-                false, false, true);
+                false, false);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -18,7 +18,7 @@ public class ClearCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.setAddressBook(new AddressBook());
-        CommandResult commandResult = new CommandResult(MESSAGE_SUCCESS, false, false, true);
+        CommandResult commandResult = new CommandResult(MESSAGE_SUCCESS, false, false);
         return commandResult;
     }
 }

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -19,17 +19,13 @@ public class CommandResult {
     /** The application should exit. */
     private final boolean exit;
 
-    /** Indicates weather the contact details panel needs to be updated. */
-    private final boolean updatePanel;
-
     /**
      * Constructs a {@code CommandResult} with the specified fields.
      */
-    public CommandResult(String feedbackToUser, boolean showHelp, boolean exit, boolean updatePanel) {
+    public CommandResult(String feedbackToUser, boolean showHelp, boolean exit) {
         this.feedbackToUser = requireNonNull(feedbackToUser);
         this.showHelp = showHelp;
         this.exit = exit;
-        this.updatePanel = updatePanel;
     }
 
     /**
@@ -37,15 +33,7 @@ public class CommandResult {
      * and other fields set to their default value.
      */
     public CommandResult(String feedbackToUser) {
-        this(feedbackToUser, false, false, false);
-    }
-
-    /**
-     * Constructs a {@code CommandResult} with the specified {@code feedbackToUser},
-     * and other fields set to their default value excep updatePanel.
-     */
-    public CommandResult(String feedbackToUser, boolean updatePanel) {
-        this(feedbackToUser, false, false, updatePanel);
+        this(feedbackToUser, false, false);
     }
 
     public String getFeedbackToUser() {
@@ -74,13 +62,12 @@ public class CommandResult {
         CommandResult otherCommandResult = (CommandResult) other;
         return feedbackToUser.equals(otherCommandResult.feedbackToUser)
                 && showHelp == otherCommandResult.showHelp
-                && exit == otherCommandResult.exit
-                && updatePanel == otherCommandResult.updatePanel;
+                && exit == otherCommandResult.exit;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(feedbackToUser, showHelp, exit, updatePanel);
+        return Objects.hash(feedbackToUser, showHelp, exit);
     }
 
     @Override
@@ -89,8 +76,6 @@ public class CommandResult {
                 .add("feedbackToUser", feedbackToUser)
                 .add("showHelp", showHelp)
                 .add("exit", exit)
-                .add("updatePanel", updatePanel)
                 .toString();
     }
-
 }

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -60,15 +60,6 @@ public class CommandResult {
         return exit;
     }
 
-    /**
-     * Gets the value of clearDetailsPanel.
-     *
-     * @return true if the details panel should be cleared; false otherwise.
-     */
-    public boolean isUpdatePanel() {
-        return this.updatePanel;
-    }
-
     @Override
     public boolean equals(Object other) {
         if (other == this) {

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -42,7 +42,7 @@ public class DeleteCommand extends Command {
 
         Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deletePerson(personToDelete);
-        model.setFocusedPerson(null);
+        model.getFocusedPerson().set(null);
         CommandResult commandResult = new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS,
                 Messages.formatShort(personToDelete)), false, false, true);
         System.out.println(commandResult.getFeedbackToUser());

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -44,7 +44,7 @@ public class DeleteCommand extends Command {
         model.deletePerson(personToDelete);
         model.getFocusedPerson().set(null);
         CommandResult commandResult = new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS,
-                Messages.formatShort(personToDelete)), false, false, true);
+                Messages.formatShort(personToDelete)), false, false);
         System.out.println(commandResult.getFeedbackToUser());
         return commandResult;
     }

--- a/src/main/java/seedu/address/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExitCommand.java
@@ -13,7 +13,7 @@ public class ExitCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true, false);
+        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true);
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommand.java
@@ -16,6 +16,6 @@ public class HelpCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(SHOWING_HELP_MESSAGE, true, false, false);
+        return new CommandResult(SHOWING_HELP_MESSAGE, true, false);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewCommand.java
@@ -41,7 +41,8 @@ public class ViewCommand extends Command {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
 
-        model.setFocusedPerson(targetIndex);
+        Person person = personList.get(targetIndex.getZeroBased());
+        model.getFocusedPerson().set(person);
 
         return new CommandResult(String.format(MESSAGE_VIEW_PERSON_SUCCESS, targetIndex.getOneBased()),
         false, false, true);

--- a/src/main/java/seedu/address/logic/commands/ViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewCommand.java
@@ -44,8 +44,7 @@ public class ViewCommand extends Command {
         Person person = personList.get(targetIndex.getZeroBased());
         model.getFocusedPerson().set(person);
 
-        return new CommandResult(String.format(MESSAGE_VIEW_PERSON_SUCCESS, targetIndex.getOneBased()),
-        false, false, true);
+        return new CommandResult(String.format(MESSAGE_VIEW_PERSON_SUCCESS, targetIndex.getOneBased()), false, false);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -3,9 +3,9 @@ package seedu.address.model;
 import java.nio.file.Path;
 import java.util.function.Predicate;
 
+import javafx.beans.property.ObjectProperty;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
-import seedu.address.commons.core.index.Index;
 import seedu.address.model.person.Person;
 
 /**
@@ -43,7 +43,7 @@ public interface Model {
     /**
      * Returns the person who will be focused on.
      */
-    Person getFocusedPerson();
+    ObjectProperty<Person> getFocusedPerson();
 
     /**
      * Sets the user prefs' address book file path.
@@ -81,13 +81,6 @@ public interface Model {
      * The person identity of {@code editedPerson} must not be the same as another existing person in the address book.
      */
     void setPerson(Person target, Person editedPerson);
-
-    /**
-     * Sets the {@code person} in the contact to be focused on in the addressbook.
-     *
-     * @param index The index of the {@code Person} in the contact list.
-     */
-    void setFocusedPerson(Index index);
 
     /** Returns an unmodifiable view of the filtered person list */
     ObservableList<Person> getFilteredPersonList();

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -7,11 +7,11 @@ import java.nio.file.Path;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
+import javafx.beans.property.ObjectProperty;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
-import seedu.address.commons.core.index.Index;
 import seedu.address.model.person.Person;
 
 /**
@@ -23,7 +23,7 @@ public class ModelManager implements Model {
     private final AddressBook addressBook;
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
-    private Person focusedPerson;
+    private final ObjectProperty<Person> focusedPerson;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -36,7 +36,7 @@ public class ModelManager implements Model {
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
-        this.focusedPerson = null;
+        this.focusedPerson = Person.personProperty(null);
     }
 
     public ModelManager() {
@@ -91,7 +91,7 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public Person getFocusedPerson() {
+    public ObjectProperty<Person> getFocusedPerson() {
         return this.focusedPerson;
     }
 
@@ -117,15 +117,6 @@ public class ModelManager implements Model {
         requireAllNonNull(target, editedPerson);
 
         addressBook.setPerson(target, editedPerson);
-    }
-
-    @Override
-    public void setFocusedPerson(Index index) {
-        if (index == null) {
-            this.focusedPerson = null;
-        } else {
-            this.focusedPerson = this.filteredPersons.get(index.getZeroBased());
-        }
     }
 
     //=========== Filtered Person List Accessors =============================================================

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
+import java.util.Objects;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
@@ -150,7 +151,7 @@ public class ModelManager implements Model {
         ModelManager otherModelManager = (ModelManager) other;
         return addressBook.equals(otherModelManager.addressBook)
                 && userPrefs.equals(otherModelManager.userPrefs)
-                && filteredPersons.equals(otherModelManager.filteredPersons);
+                && filteredPersons.equals(otherModelManager.filteredPersons)
+                && Objects.equals(focusedPerson.get(), otherModelManager.focusedPerson.get());
     }
-
 }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -10,7 +10,6 @@ import java.util.Set;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.ObjectPropertyBase;
 import seedu.address.commons.util.ToStringBuilder;
-import seedu.address.model.ModelManager;
 import seedu.address.model.tag.Tag;
 
 /**

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -7,6 +7,8 @@ import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;
 
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.ObjectPropertyBase;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.model.tag.Tag;
 
@@ -79,6 +81,29 @@ public class Person {
 
         return otherPerson != null
                 && otherPerson.getName().equals(getName());
+    }
+
+    /**
+     * Wraps the Person so that it becomes an ObjectProperty
+     *
+     * @param person the person to wrap around
+     * @return an ObjectProperty of the person
+     * @see ObjectProperty
+     */
+    public static ObjectProperty<Person> personProperty(Person person) {
+        ObjectProperty<Person> property = new ObjectPropertyBase<>() {
+            @Override
+            public Object getBean() {
+                return null;
+            }
+
+            @Override
+            public String getName() {
+                return "Person";
+            }
+        };
+        property.set(person);
+        return property;
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.ObjectPropertyBase;
 import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.ModelManager;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -99,7 +100,7 @@ public class Person {
 
             @Override
             public String getName() {
-                return "Person";
+                return "";
             }
         };
         property.set(person);

--- a/src/main/java/seedu/address/ui/ContactDetails.java
+++ b/src/main/java/seedu/address/ui/ContactDetails.java
@@ -3,12 +3,14 @@ package seedu.address.ui;
 import java.util.Comparator;
 import java.util.logging.Logger;
 
+import javafx.beans.property.ObjectProperty;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.model.person.Note;
 import seedu.address.model.person.Person;
 
 /**
@@ -18,8 +20,6 @@ public class ContactDetails extends UiPart<Region> {
 
     private static final String FXML = "ContactDetails.fxml";
     private final Logger logger = LogsCenter.getLogger(ContactDetails.class);
-
-    private Person person;
 
     @FXML
     private HBox contactDetailsPanel;
@@ -45,20 +45,41 @@ public class ContactDetails extends UiPart<Region> {
     /**
      * Creates a {@code ContactDetailsPanel} with the given {@code Person} information.
      */
-    public ContactDetails(Person person) {
+    public ContactDetails(ObjectProperty<Person> person) {
         super(FXML);
-        this.person = person;
+        person.addListener((observable, oldValue, newValue) -> displayPerson(newValue));
+    }
+
+    private void addNote(String note) {
+        Label label = new Label("• " + note);
+        // TODO: use classes instead
+        label.setId("notes-label");
+        notesList.getChildren().add(label);
     }
 
     /**
      * Sets the person object as the contact to be displayed on the panel.
      *
      * @param person The person object to be updated onto the panel.
-     */
-    public void setPerson(Person person) {
-        this.person = person;
-        this.clearPanel();
-        this.setPanelInformation();
+    */
+    private void displayPerson(Person person) {
+        logger.info("Displaying info of " + person.toString());
+        clearPanel();
+
+        name.setText(person.getName().fullName);
+        phoneNo.setText("Mobile: " + person.getPhone().toString());
+        email.setText("Email: " + person.getEmail().toString());
+        address.setText("Address: " + person.getAddress().toString());
+
+        if (!person.getNotes().isEmpty()) {
+            Label notesHeader = new Label("Notes");
+            notesHeader.setId("notes-header");
+            notesList.getChildren().add(notesHeader);
+        }
+
+        person.getNotes().stream()
+            .sorted(Comparator.comparing(Note::getNote))
+            .forEach(note -> addNote(note.getNote()));
     }
 
     /**
@@ -72,33 +93,5 @@ public class ContactDetails extends UiPart<Region> {
         address.setText("");
         notes.setText("");
         notesList.getChildren().clear();
-    }
-
-    /**
-     * Adds the contact details of the person into the panel.
-     */
-    private void setPanelInformation() {
-        // Update with new person details if person is not null
-        if (person != null) {
-            logger.info("Displaying info of " + person.toString());
-
-            name.setText(person.getName().fullName);
-            phoneNo.setText("Mobile: " + person.getPhone().toString());
-            email.setText("Email: " + person.getEmail().toString());
-            address.setText("Address: " + person.getAddress().toString());
-
-            if (!person.getNotes().isEmpty()) {
-                Label notesHeader = new Label("Notes");
-                notesHeader.setId("notes-header");
-                notesList.getChildren().add(notesHeader);
-                person.getNotes().stream()
-                        .sorted(Comparator.comparing(note -> note.getNote()))
-                        .forEach(note -> {
-                            Label label = new Label("• " + note.getNote());
-                            label.setId("notes-label");
-                            notesList.getChildren().add(label);
-                        });
-            }
-        }
     }
 }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -153,13 +153,6 @@ public class MainWindow extends UiPart<Stage> {
     }
 
     /**
-     * Updates the contact details panel for the seleted contact.
-     */
-    public void handlePanelUpdate() {
-        contactDetailsPanel.setPerson(logic.getFocusedPerson());
-    }
-
-    /**
      * Opens the help window or focuses on it if it's already opened.
      */
     @FXML
@@ -197,10 +190,6 @@ public class MainWindow extends UiPart<Stage> {
             CommandResult commandResult = logic.execute(commandText);
             logger.info("Result: " + commandResult.getFeedbackToUser());
             resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
-
-            if (commandResult.isUpdatePanel()) {
-                handlePanelUpdate();
-            }
 
             if (commandResult.isShowHelp()) {
                 handleHelp();

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -123,8 +123,7 @@ public class MainWindow extends UiPart<Stage> {
         contactDetailsPanel = new ContactDetails(logic.getFocusedPerson());
         contactDetailsPanelPlaceholder.getChildren().add(contactDetailsPanel.getRoot());
 
-        personListPanel = new PersonListPanel(logic.getFilteredPersonList());
-        personListPanel.setContactDetailsPanel(contactDetailsPanel);
+        personListPanel = new PersonListPanel(logic.getFilteredPersonList(), logic.getFocusedPerson());
         personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
 
         resultDisplay = new ResultDisplay();

--- a/src/main/java/seedu/address/ui/PersonListPanel.java
+++ b/src/main/java/seedu/address/ui/PersonListPanel.java
@@ -2,6 +2,7 @@ package seedu.address.ui;
 
 import java.util.logging.Logger;
 
+import javafx.beans.property.ObjectProperty;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.ListCell;
@@ -21,42 +22,28 @@ public class PersonListPanel extends UiPart<Region> {
     @FXML
     private ListView<Person> personListView;
 
-    private ContactDetails contactDetails;
-
     /**
      * Creates a {@code PersonListPanel} with the given {@code ObservableList}.
      */
-    public PersonListPanel(ObservableList<Person> personList) {
+    public PersonListPanel(ObservableList<Person> personList, ObjectProperty<Person> focusedPerson) {
         super(FXML);
         personListView.setItems(personList);
         personListView.setCellFactory(listView -> new PersonListViewCell());
 
         // Add event handler
-        personListView.setOnMouseClicked(this::handleListViewClick);
-    }
-
-    /**
-     * Sets the contactDetails panel.
-     *
-     * @param contactDetails The contactDetails object to be stored.
-     */
-    public void setContactDetailsPanel(ContactDetails contactDetails) {
-        this.contactDetails = contactDetails;
-
-        // Logging here to verify the setter works
-        logger.finer("ContactDetails reference: " + this.contactDetails);
+        personListView.setOnMouseClicked(event -> handleListViewClick(event, focusedPerson));
     }
 
     /**
      * When user clicks on a person, the details plane changes.
      */
-    private void handleListViewClick(MouseEvent event) {
+    private void handleListViewClick(MouseEvent event, ObjectProperty<Person> focusedPerson) {
         // Get the index of the clicked item
         int index = personListView.getSelectionModel().getSelectedIndex();
         Person selectedPerson = personListView.getSelectionModel().getSelectedItem();
 
         if (index != -1) {
-            contactDetails.setPerson(selectedPerson);
+            focusedPerson.set(selectedPerson);
             logger.info("Clicked on person: " + selectedPerson + " at index " + index);
         } else {
             logger.info("Clicked on an empty area of the ListView");

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -14,9 +14,9 @@ import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
+import javafx.beans.property.ObjectProperty;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
-import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
@@ -115,7 +115,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public Person getFocusedPerson() {
+        public ObjectProperty<Person> getFocusedPerson() {
             throw new AssertionError("This method should not be called.");
         }
 
@@ -151,11 +151,6 @@ public class AddCommandTest {
 
         @Override
         public void setPerson(Person target, Person editedPerson) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setFocusedPerson(Index index) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
@@ -1,6 +1,6 @@
 package seedu.address.logic.commands;
 
-import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccessWithPanelUpdate;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
@@ -16,7 +16,7 @@ public class ClearCommandTest {
     public void execute_emptyAddressBook_success() {
         Model model = new ModelManager();
         Model expectedModel = new ModelManager();
-        assertCommandSuccessWithPanelUpdate(new ClearCommand(), model, ClearCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     @Test
@@ -25,7 +25,7 @@ public class ClearCommandTest {
         Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
         expectedModel.setAddressBook(new AddressBook());
 
-        assertCommandSuccessWithPanelUpdate(new ClearCommand(), model, ClearCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/CommandResultTest.java
+++ b/src/test/java/seedu/address/logic/commands/CommandResultTest.java
@@ -14,7 +14,7 @@ public class CommandResultTest {
 
         // same values -> returns true
         assertTrue(commandResult.equals(new CommandResult("feedback")));
-        assertTrue(commandResult.equals(new CommandResult("feedback", false, false, false)));
+        assertTrue(commandResult.equals(new CommandResult("feedback", false, false)));
 
         // same object -> returns true
         assertTrue(commandResult.equals(commandResult));
@@ -29,13 +29,10 @@ public class CommandResultTest {
         assertFalse(commandResult.equals(new CommandResult("different")));
 
         // different showHelp value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", true, false, false)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", true, false)));
 
         // different exit value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", false, true, false)));
-
-        // different updatePanel value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", false, false, true)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", false, true)));
     }
 
     @Test
@@ -49,13 +46,10 @@ public class CommandResultTest {
         assertNotEquals(commandResult.hashCode(), new CommandResult("different").hashCode());
 
         // different showHelp value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", true, false, false).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", true, false).hashCode());
 
         // different exit value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, true, false).hashCode());
-
-        // different updatePanel value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, false, true).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, true).hashCode());
     }
 
     @Test
@@ -63,8 +57,7 @@ public class CommandResultTest {
         CommandResult commandResult = new CommandResult("feedback");
         String expected = CommandResult.class.getCanonicalName() + "{feedbackToUser="
                 + commandResult.getFeedbackToUser() + ", showHelp=" + commandResult.isShowHelp()
-                + ", exit=" + commandResult.isExit()
-                + ", updatePanel=" + commandResult.isUpdatePanel() + "}";
+                + ", exit=" + commandResult.isExit() + "}";
         assertEquals(expected, commandResult.toString());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -91,17 +91,7 @@ public class CommandTestUtil {
      */
     public static void assertCommandSuccess(Command command, Model actualModel, String expectedMessage,
             Model expectedModel) {
-        CommandResult expectedCommandResult = new CommandResult(expectedMessage, false);
-        assertCommandSuccess(command, actualModel, expectedCommandResult, expectedModel);
-    }
-
-    /**
-     * Convenience wrapper to {@link #assertCommandSuccess(Command, Model, CommandResult, Model)}
-     * that takes a string {@code expectedMessage}.
-     */
-    public static void assertCommandSuccessWithPanelUpdate(Command command, Model actualModel, String expectedMessage,
-            Model expectedModel) {
-        CommandResult expectedCommandResult = new CommandResult(expectedMessage, true);
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage);
         assertCommandSuccess(command, actualModel, expectedCommandResult, expectedModel);
     }
 

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
-import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccessWithPanelUpdate;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_OUTOFBOUND_PERSON;
@@ -39,7 +39,7 @@ public class DeleteCommandTest {
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deletePerson(personToDelete);
 
-        assertCommandSuccessWithPanelUpdate(deleteCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
@@ -64,7 +64,7 @@ public class DeleteCommandTest {
         expectedModel.deletePerson(personToDelete);
         showNoPerson(expectedModel);
 
-        assertCommandSuccessWithPanelUpdate(deleteCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
@@ -14,7 +14,7 @@ public class ExitCommandTest {
 
     @Test
     public void execute_exit_success() {
-        CommandResult expectedCommandResult = new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true, false);
+        CommandResult expectedCommandResult = new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true);
         assertCommandSuccess(new ExitCommand(), model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
@@ -14,7 +14,7 @@ public class HelpCommandTest {
 
     @Test
     public void execute_help_success() {
-        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false, false);
+        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false);
         assertCommandSuccess(new HelpCommand(), model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.Person;
 import seedu.address.testutil.AddressBookBuilder;
 
 public class ModelManagerTest {
@@ -123,6 +124,14 @@ public class ModelManagerTest {
 
         // resets modelManager to initial state for upcoming tests
         modelManager.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+
+        // different focusedPerson -> returns false
+        Person defaultPerson = modelManager.getFocusedPerson().get();
+        modelManager.getFocusedPerson().set(ALICE);
+        assertFalse(modelManager.equals(new ModelManager(addressBook, userPrefs)));
+
+        // resets modelManager to initial state for upcoming tests
+        modelManager.getFocusedPerson().set(defaultPerson);
 
         // different userPrefs -> returns false
         UserPrefs differentUserPrefs = new UserPrefs();


### PR DESCRIPTION
Closes #170 

This PR implements `Person.personProperty(Person)` which returns a `ObjectProperty<Person>` that wraps around the given person.

The main changes:
- `CommandResult` does not have `updatePanel` anymore
- `contactDetails.setPerson` is not used to update the panel anymore (the panel just observes `focusedPerson` now)
- `PersonListPanel` does not accept `ContactDetails` as a parameter anymore
- `Model` and `Logic` provide `getFocusedPerson` only now