### PR TITLE
Fix VCFExporter to write structured name and only write categories if needed

### DIFF
--- a/src/main/java/bizbook/logic/commands/exporter/VcfExporter.java
+++ b/src/main/java/bizbook/logic/commands/exporter/VcfExporter.java
@@ -14,6 +14,7 @@ import ezvcard.Ezvcard;
 import ezvcard.VCard;
 import ezvcard.property.Address;
 import ezvcard.property.Categories;
+import ezvcard.property.StructuredName;
 
 /**
  * Represents a class that can export to VCF
@@ -46,18 +47,29 @@ public class VcfExporter implements Exporter {
 
     private VCard convertToVcf(Person person) {
         // Convert attributes to vCard representable properties
+        // Since we have no indication of which parts of the name is which, set
+        // the given name as full name
+        StructuredName structuredName = new StructuredName();
+        structuredName.setGiven(person.getName().fullName);
+
         Address address = new Address();
         address.setStreetAddress(person.getAddress().value);
 
         Categories categories = new Categories();
         person.getTags().forEach(tag -> categories.getValues().add(tag.tagName));
 
+        // Create vCard
         VCard vCard = new VCard();
         vCard.setFormattedName(person.getName().fullName);
+        vCard.setStructuredName(structuredName);
         vCard.addTelephoneNumber(person.getPhone().value);
         vCard.addEmail(person.getEmail().value);
         vCard.addAddress(address);
-        vCard.setCategories(categories);
+
+        if (!categories.getValues().isEmpty()) {
+            vCard.setCategories(categories);
+        }
+
         person.getNotes()
                 .forEach(note -> vCard.addNote(note.getNote()));
 

--- a/src/test/java/bizbook/logic/commands/exporter/VcfExporterTest.java
+++ b/src/test/java/bizbook/logic/commands/exporter/VcfExporterTest.java
@@ -3,6 +3,7 @@ package bizbook.logic.commands.exporter;
 import static bizbook.testutil.TypicalPersons.AMY;
 import static bizbook.testutil.TypicalPersons.BOB;
 import static bizbook.testutil.TypicalPersons.CHARLIE;
+import static bizbook.testutil.TypicalPersons.getTypicalAddressBook;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -15,6 +16,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Path;
+import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -24,6 +26,8 @@ import bizbook.commons.util.FileUtil;
 import bizbook.logic.commands.exporter.exceptions.EmptyAddressBookException;
 import bizbook.model.AddressBook;
 import bizbook.model.UserPrefs;
+import ezvcard.Ezvcard;
+import ezvcard.VCard;
 
 
 public class VcfExporterTest {
@@ -119,6 +123,19 @@ public class VcfExporterTest {
             assertEquals(expectedValue, actualValue);
         } catch (IOException ie) {
             fail(ie);
+        }
+    }
+
+    @Test
+    public void export_multiplePeople_isValidVcf() throws IOException {
+        vcfExporter.exportAddressBook(getTypicalAddressBook());
+
+        Path exportPath = vcfExporter.getExportPath();
+        String contents = FileUtil.readFromFile(exportPath);
+        List<VCard> vCards = Ezvcard.parse(contents).all();
+
+        for (VCard vCard : vCards) {
+            assertTrue(vCard.validate(vCard.getVersion()).isEmpty());
         }
     }
 }

--- a/src/test/resources/logic/commands/exporter/VcfExporterTest/charlie.vcf
+++ b/src/test/resources/logic/commands/exporter/VcfExporterTest/charlie.vcf
@@ -2,6 +2,7 @@ BEGIN:VCARD
 VERSION:3.0
 PRODID:ez-vcard 0.12.1
 FN:Charlie Dee
+N:;Charlie Dee
 TEL:81111111
 EMAIL:charlie@example.com
 ADR:;;Block 987\, Charlie Street 2

--- a/src/test/resources/logic/commands/exporter/VcfExporterTest/people.vcf
+++ b/src/test/resources/logic/commands/exporter/VcfExporterTest/people.vcf
@@ -2,6 +2,7 @@ BEGIN:VCARD
 VERSION:3.0
 PRODID:ez-vcard 0.12.1
 FN:Amy Bee
+N:;Amy Bee
 TEL:91111111
 EMAIL:amy@example.com
 ADR:;;Block 312\, Amy Street 1
@@ -11,6 +12,7 @@ BEGIN:VCARD
 VERSION:3.0
 PRODID:ez-vcard 0.12.1
 FN:Bob Choo
+N:;Bob Choo
 TEL:62222222
 EMAIL:bob@example.com
 ADR:;;Block 123\, Bobby Street 3
@@ -20,6 +22,7 @@ BEGIN:VCARD
 VERSION:3.0
 PRODID:ez-vcard 0.12.1
 FN:Charlie Dee
+N:;Charlie Dee
 TEL:81111111
 EMAIL:charlie@example.com
 ADR:;;Block 987\, Charlie Street 2


### PR DESCRIPTION
Closes #251

I have added a test case that fails to show the effects of not having the structured name.