### PR TITLE
Bug fix: Add duplicate note check where capital is considered

### DIFF
--- a/src/main/java/bizbook/logic/commands/AddNoteCommand.java
+++ b/src/main/java/bizbook/logic/commands/AddNoteCommand.java
@@ -60,8 +60,10 @@ public class AddNoteCommand extends Command {
 
         ArrayList<Note> notesList = new ArrayList<>(personToEdit.getNotes());
 
-        if (notesList.contains(note)) {
-            throw new CommandException(DUPLICATE_MESSAGE_CONSTRAINTS);
+        for (Note existingNote : notesList) {
+            if (existingNote.toString().equalsIgnoreCase(note.toString())) {
+                throw new CommandException(DUPLICATE_MESSAGE_CONSTRAINTS);
+            }
         }
 
         notesList.add(note);

--- a/src/main/java/bizbook/logic/commands/AddNoteCommand.java
+++ b/src/main/java/bizbook/logic/commands/AddNoteCommand.java
@@ -26,7 +26,7 @@ public class AddNoteCommand extends Command {
             + "by the person index number used on the left display panel. "
             + "New note(letters and numbers) will be appended to the notes currently stored.\n"
             + "Parameters: INDEX (must be a positive integer) "
-            + "n/[NOTE]\n"
+            + "n/NOTE\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + "n/High profile client.";
 
@@ -60,10 +60,8 @@ public class AddNoteCommand extends Command {
 
         ArrayList<Note> notesList = new ArrayList<>(personToEdit.getNotes());
 
-        for (Note existingNote : notesList) {
-            if (existingNote.toString().equalsIgnoreCase(note.toString())) {
-                throw new CommandException(DUPLICATE_MESSAGE_CONSTRAINTS);
-            }
+        if (notesList.contains(note)) {
+            throw new CommandException(DUPLICATE_MESSAGE_CONSTRAINTS);
         }
 
         notesList.add(note);

--- a/src/main/java/bizbook/logic/commands/DeleteNoteCommand.java
+++ b/src/main/java/bizbook/logic/commands/DeleteNoteCommand.java
@@ -25,7 +25,7 @@ public class DeleteNoteCommand extends Command {
             + ": Deletes the note of the person identified "
             + "by the index number used in the person listing and the index of the note.\n"
             + "Parameters: INDEX (must be a positive integer) "
-            + "i/[NOTE_INDEX]\n"
+            + "i/NOTE_INDEX\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + "i/1";
 

--- a/src/main/java/bizbook/logic/commands/EditNoteCommand.java
+++ b/src/main/java/bizbook/logic/commands/EditNoteCommand.java
@@ -24,7 +24,7 @@ public class EditNoteCommand extends Command {
             + ": Edits the note of the person identified "
             + "by the person index number used on the left display panel. "
             + "The note will replace the currently stored note at the specified index.\n"
-            + "Parameters: INDEX i/[NOTE_INDEX] n/[NOTE]\n"
+            + "Parameters: INDEX i/NOTE_INDEX n/NOTE\n"
             + "Example: " + COMMAND_WORD + " 1 i/1 n/High profile client.";
 
     public static final String MESSAGE_EDIT_NOTE_SUCCESS = "Edit note of Person: %1$s";

--- a/src/main/java/bizbook/model/person/Note.java
+++ b/src/main/java/bizbook/model/person/Note.java
@@ -44,13 +44,13 @@ public class Note {
 
         Note otherNotes = (Note) other;
 
-        return note.equals(otherNotes.note);
+        return note.equalsIgnoreCase(otherNotes.note);
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(note);
+        return Objects.hash(note.toLowerCase());
     }
 
     /**

--- a/src/test/java/bizbook/logic/commands/AddNoteCommandTest.java
+++ b/src/test/java/bizbook/logic/commands/AddNoteCommandTest.java
@@ -1,5 +1,6 @@
 package bizbook.logic.commands;
 
+import static bizbook.logic.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 import static bizbook.logic.commands.CommandTestUtil.VALID_NOTE_ALICE;
 import static bizbook.logic.commands.CommandTestUtil.VALID_NOTE_BOB;
 import static bizbook.logic.commands.CommandTestUtil.VALID_NOTE_HIGH_PROFILE_CLIENT;
@@ -8,8 +9,12 @@ import static bizbook.testutil.PersonBuilder.DEFAULT_ADDRESS;
 import static bizbook.testutil.PersonBuilder.DEFAULT_EMAIL;
 import static bizbook.testutil.PersonBuilder.DEFAULT_NAME;
 import static bizbook.testutil.PersonBuilder.DEFAULT_PHONE;
+import static bizbook.testutil.TypicalIndexes.INDEX_FIRST_NOTE;
 import static bizbook.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static bizbook.testutil.TypicalIndexes.INDEX_OUTOFBOUND_PERSON;
 import static bizbook.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static bizbook.testutil.TypicalNotes.TYPICAL_NOTE;
+import static bizbook.testutil.TypicalPersons.getTypicalAddressBook;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -21,6 +26,8 @@ import org.junit.jupiter.api.Test;
 import bizbook.commons.core.index.Index;
 import bizbook.logic.commands.exceptions.CommandException;
 import bizbook.model.Model;
+import bizbook.model.ModelManager;
+import bizbook.model.UserPrefs;
 import bizbook.model.person.Note;
 import bizbook.model.person.Person;
 import bizbook.testutil.PersonBuilder;
@@ -30,6 +37,8 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 
 public class AddNoteCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
     public void constructor_nullFields_throwsNullPointerException() {
@@ -97,6 +106,15 @@ public class AddNoteCommandTest {
         assertThrows(CommandException.class, AddNoteCommand.DUPLICATE_MESSAGE_CONSTRAINTS, () ->
                 addNoteCommand.execute(modelMock));
     }
+
+
+//    @Test
+//    public void execute_invalidPersonIndex_throwsCommandException() {
+//        EditNoteCommand editNoteCommand = new EditNoteCommand(INDEX_OUTOFBOUND_PERSON, INDEX_FIRST_NOTE,
+//                TYPICAL_NOTE);
+//        assertThrows(CommandException.class, MESSAGE_INVALID_PERSON_DISPLAYED_INDEX, () ->
+//                editNoteCommand.execute(model));
+//    }
 
     @Test
     public void equals() {

--- a/src/test/java/bizbook/logic/commands/AddNoteCommandTest.java
+++ b/src/test/java/bizbook/logic/commands/AddNoteCommandTest.java
@@ -108,13 +108,13 @@ public class AddNoteCommandTest {
     }
 
 
-//    @Test
-//    public void execute_invalidPersonIndex_throwsCommandException() {
-//        EditNoteCommand editNoteCommand = new EditNoteCommand(INDEX_OUTOFBOUND_PERSON, INDEX_FIRST_NOTE,
-//                TYPICAL_NOTE);
-//        assertThrows(CommandException.class, MESSAGE_INVALID_PERSON_DISPLAYED_INDEX, () ->
-//                editNoteCommand.execute(model));
-//    }
+    @Test
+    public void execute_invalidPersonIndex_throwsCommandException() {
+        AddNoteCommand addNoteCommand = new AddNoteCommand(INDEX_OUTOFBOUND_PERSON,
+                TYPICAL_NOTE);
+        assertThrows(CommandException.class, MESSAGE_INVALID_PERSON_DISPLAYED_INDEX, () ->
+                addNoteCommand.execute(model));
+    }
 
     @Test
     public void equals() {

--- a/src/test/java/bizbook/logic/commands/AddNoteCommandTest.java
+++ b/src/test/java/bizbook/logic/commands/AddNoteCommandTest.java
@@ -9,7 +9,6 @@ import static bizbook.testutil.PersonBuilder.DEFAULT_ADDRESS;
 import static bizbook.testutil.PersonBuilder.DEFAULT_EMAIL;
 import static bizbook.testutil.PersonBuilder.DEFAULT_NAME;
 import static bizbook.testutil.PersonBuilder.DEFAULT_PHONE;
-import static bizbook.testutil.TypicalIndexes.INDEX_FIRST_NOTE;
 import static bizbook.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static bizbook.testutil.TypicalIndexes.INDEX_OUTOFBOUND_PERSON;
 import static bizbook.testutil.TypicalIndexes.INDEX_SECOND_PERSON;

--- a/src/test/java/bizbook/logic/commands/CommandTestUtil.java
+++ b/src/test/java/bizbook/logic/commands/CommandTestUtil.java
@@ -45,6 +45,7 @@ public class CommandTestUtil {
     public static final String VALID_NOTE_ALICE = "Alice note";
     public static final String VALID_NOTE_BOB = "Bob note";
     public static final String VALID_NOTE_HIGH_PROFILE_CLIENT = "High profile client";
+    public static final String VALID_NOTE_HIGH_PROFILE_CLIENT_LOWERCASE = "high profile client";
 
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;

--- a/src/test/java/bizbook/logic/commands/EditNoteCommandTest.java
+++ b/src/test/java/bizbook/logic/commands/EditNoteCommandTest.java
@@ -68,7 +68,7 @@ public class EditNoteCommandTest {
     @Test
     public void execute_invalidPersonIndex_throwsCommandException() {
         EditNoteCommand editNoteCommand = new EditNoteCommand(INDEX_OUTOFBOUND_PERSON, INDEX_FIRST_NOTE,
-                DUPLICATE_NOTE);
+                TYPICAL_NOTE);
         assertThrows(CommandException.class, MESSAGE_INVALID_PERSON_DISPLAYED_INDEX, () ->
                 editNoteCommand.execute(model));
     }

--- a/src/test/java/bizbook/model/person/NoteTest.java
+++ b/src/test/java/bizbook/model/person/NoteTest.java
@@ -1,6 +1,7 @@
 package bizbook.model.person;
 
 import static bizbook.logic.commands.CommandTestUtil.VALID_NOTE_HIGH_PROFILE_CLIENT;
+import static bizbook.logic.commands.CommandTestUtil.VALID_NOTE_HIGH_PROFILE_CLIENT_LOWERCASE;
 import static bizbook.testutil.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -50,6 +51,9 @@ public class NoteTest {
 
         // same object -> returns true
         assertTrue(note.equals(note));
+
+        // capitalised and non capitalised -> returns true
+        assertTrue(note.equals(new Note(VALID_NOTE_HIGH_PROFILE_CLIENT_LOWERCASE)));
 
         // null -> returns false
         assertFalse(note.equals(null));

--- a/src/test/java/bizbook/testutil/TypicalIndexes.java
+++ b/src/test/java/bizbook/testutil/TypicalIndexes.java
@@ -10,6 +10,7 @@ public class TypicalIndexes {
     public static final Index INDEX_SECOND_PERSON = Index.fromOneBased(2);
     public static final Index INDEX_THIRD_PERSON = Index.fromOneBased(3);
     public static final Index INDEX_OUTOFBOUND_PERSON = Index.fromOneBased(1000);
+    public static final Index INDEX_OUTOFBOUND_NEGATIVE_PERSON = Index.fromOneBased(-1);
 
 
     public static final Index INDEX_FIRST_NOTE = Index.fromOneBased(1);

--- a/src/test/java/bizbook/testutil/TypicalIndexes.java
+++ b/src/test/java/bizbook/testutil/TypicalIndexes.java
@@ -10,8 +10,6 @@ public class TypicalIndexes {
     public static final Index INDEX_SECOND_PERSON = Index.fromOneBased(2);
     public static final Index INDEX_THIRD_PERSON = Index.fromOneBased(3);
     public static final Index INDEX_OUTOFBOUND_PERSON = Index.fromOneBased(1000);
-    public static final Index INDEX_OUTOFBOUND_NEGATIVE_PERSON = Index.fromOneBased(-1);
-
 
     public static final Index INDEX_FIRST_NOTE = Index.fromOneBased(1);
     public static final Index INDEX_OUTOFBOUND_NOTE = Index.fromOneBased(1000);


### PR DESCRIPTION
Closes #267
Fixs duplicate note check for lowercase + uppercase as well as update message usages of add, edit and delete notes