### PR TITLE
Update ContactDetails to use ScrollPane and wrap text

### DIFF
--- a/src/main/java/bizbook/ui/ContactDetails.java
+++ b/src/main/java/bizbook/ui/ContactDetails.java
@@ -8,7 +8,7 @@ import bizbook.model.person.Person;
 import javafx.beans.property.ObjectProperty;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
-import javafx.scene.layout.HBox;
+import javafx.scene.control.ScrollPane;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
 
@@ -21,7 +21,7 @@ public class ContactDetails extends UiPart<Region> {
     private final Logger logger = LogsCenter.getLogger(ContactDetails.class);
 
     @FXML
-    private HBox contactDetailsPanel;
+    private ScrollPane contactDetailsPanel;
 
     @FXML
     private Label name;

--- a/src/main/resources/view/ContactDetails.fxml
+++ b/src/main/resources/view/ContactDetails.fxml
@@ -1,23 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Label?>
-<?import javafx.scene.layout.GridPane?>
-<?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
+<?import javafx.scene.control.ScrollPane?>
+<?import javafx.geometry.Insets?>
 
-<HBox fx:id="contactDetailsPanel" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
-  <GridPane HBox.hgrow="ALWAYS">
+<ScrollPane
+  fx:id="contactDetailsPanel"
+  xmlns="http://javafx.com/javafx/17"
+  xmlns:fx="http://javafx.com/fxml/1"
+  hbarPolicy="NEVER"
+  styleClass="pane"
+  fitToWidth="true"
+>
+  <VBox fx:id="contactDetailsBox" spacing="15">
     <padding>
-      <Insets left="10" />
+      <Insets top="10" right="10" bottom="10" left="10" />
     </padding>
-    <VBox fx:id="contactDetailsBox" spacing="15">
-      <Label fx:id="name" styleClass="label-header" />
-      <Label fx:id="phoneNo" styleClass="label-bright" />
-      <Label fx:id="email" styleClass="label-bright" />
-      <Label fx:id="address" styleClass="label-bright" />
-      <Label fx:id="notes" styleClass="label-bright" />
-      <VBox fx:id="notesList" />
-    </VBox>
-  </GridPane>
-</HBox>
+    <Label fx:id="name" styleClass="label-header" wrapText="true" />
+    <Label fx:id="phoneNo" styleClass="label-bright" wrapText="true" />
+    <Label fx:id="email" styleClass="label-bright" wrapText="true" />
+    <Label fx:id="address" styleClass="label-bright" wrapText="true" />
+    <Label fx:id="notes" styleClass="label-bright" wrapText="true" />
+    <VBox fx:id="notesList" />
+  </VBox>
+</ScrollPane>

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -39,6 +39,11 @@
     -fx-max-height: 0;
 }
 
+/* Solution below adapted from https://stackoverflow.com/a/40003066/4428725 */
+.scroll-pane .viewport {
+    -fx-background-color: transparent;
+}
+
 .table-view {
     -fx-base: #1d1d1d;
     -fx-control-inner-background: #1d1d1d;

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -44,9 +44,6 @@
           </VBox>
           <!-- Contact details panel -->
           <VBox fx:id="contactDetails" styleClass="pane-with-border" HBox.hgrow="ALWAYS">
-            <padding>
-              <Insets top="10" right="10" bottom="10" left="10" />
-            </padding>
             <StackPane fx:id="contactDetailsPanelPlaceholder" VBox.vgrow="ALWAYS" />
           </VBox>
         </HBox>


### PR DESCRIPTION

<img width="600" alt="Screenshot of ScrollPane" src="https://github.com/user-attachments/assets/f4d95c3f-fad8-4509-99fb-51145e63386b">

Updates the contact details panel to use a `ScrollPane` and made the labels `wrapText`.

Closes #272 